### PR TITLE
check headers have not been written - had to bump to 4.5.2

### DIFF
--- a/src/Serilog.Enrichers.CorrelationId.Tests/Serilog.Enrichers.CorrelationId.Tests.csproj
+++ b/src/Serilog.Enrichers.CorrelationId.Tests/Serilog.Enrichers.CorrelationId.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -10,8 +10,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Serilog.Tests</RootNamespace>
     <AssemblyName>Serilog.Enrichers.CorrelationId.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdHeaderEnricher.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdHeaderEnricher.cs
@@ -33,8 +33,11 @@ namespace Serilog.Enrichers
                 ? Guid.NewGuid().ToString()
                 : header;
 
-            HttpContext.Current.Response.AddHeader(_headerKey, correlationId);
-
+            if (!HttpContext.Current.Response.HeadersWritten)
+            {
+                HttpContext.Current.Response.AddHeader(_headerKey, correlationId);
+            }
+           
             return correlationId;
         }
     }

--- a/src/Serilog.Enrichers.CorrelationId/Serilog.Enrichers.CorrelationId.csproj
+++ b/src/Serilog.Enrichers.CorrelationId/Serilog.Enrichers.CorrelationId.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -10,8 +10,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Serilog</RootNamespace>
     <AssemblyName>Serilog.Enrichers.CorrelationId</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
fixes #3 
`HeadersWritten` is only in 4.5.2 so minimum framework has been bumped to that.

Check that we can add the correlation id to the header. 

We're using the [Serilog Web Classic](https://github.com/serilog-web/classic) package which logs requests using a HttpModule which I think means it is too far along in the pipeline to add headers.
We still end up getting the correlation id response header as we normally have log events occurring before the request completes.

A better fix would probably to have the response header set via some middleware rather than via the enricher but this at least handles the scenario.