### PR TITLE
Fixing null in log entry when CorrelationIdHeaderEnricher

### DIFF
--- a/src/Serilog.Enrichers.CorrelationId.Tests/Enrichers/CorrelationIdHeaderEnricherTests.cs
+++ b/src/Serilog.Enrichers.CorrelationId.Tests/Enrichers/CorrelationIdHeaderEnricherTests.cs
@@ -82,5 +82,28 @@ namespace Serilog.Tests.Enrichers
             Assert.NotNull(evt);
             Assert.IsFalse(evt.Properties.ContainsKey("CorrelationId"));
         }
+
+        [Test]
+        public void When_MultipleLoggingCallsMade_Should_KeepUsingCreatedCorrelationIdProperty()
+        {
+            var httpContext = new DefaultHttpContext();
+
+            A.CallTo(() => _httpContextAccessor.HttpContext)
+                .Returns(httpContext);
+
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .Enrich.With(_enricher)
+                .WriteTo.Sink(new DelegateSink.DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information(@"Has a CorrelationId property");
+
+            var correlationId = evt.Properties["CorrelationId"].LiteralValue();
+
+            log.Information(@"Here is another event");
+
+            Assert.AreEqual(correlationId, evt.Properties["CorrelationId"].LiteralValue());
+        }
     }
 }

--- a/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdHeaderEnricher.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdHeaderEnricher.cs
@@ -37,7 +37,7 @@ namespace Serilog.Enrichers
 
             var correlationIdProperty = new LogEventProperty(CorrelationIdPropertyName, new ScalarValue(correlationId));
 
-            logEvent.AddPropertyIfAbsent(correlationIdProperty);
+            logEvent.AddOrUpdateProperty(correlationIdProperty);
         }
 
         private string GetCorrelationId()

--- a/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdHeaderEnricher.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdHeaderEnricher.cs
@@ -48,6 +48,10 @@ namespace Serilog.Enrichers
             {
                 header = values.FirstOrDefault();
             }
+            else if (_contextAccessor.HttpContext.Response.Headers.TryGetValue(_headerKey, out values))
+            {
+                header = values.FirstOrDefault();
+            }
 
             var correlationId = string.IsNullOrEmpty(header)
                                     ? Guid.NewGuid().ToString()


### PR DESCRIPTION
I have this log entry:
```
!!! 2019-11-12T01:11:08.1135489+01:00 [DBG] (HappyCode.NetCoreBoilerplate.Api/LKURZYNIEC-WRO/null) '"CarsContext"' disposed.
```

with such configuration
```
  "Serilog": {
    "WriteTo": [
      {
        "Name": "Async",
        "Args": {
          "configure": [
            {
              "Name": "Console",
              "Args": {
                "outputTemplate":
                  "!!! {Timestamp:o} [{Level:u3}] ({Application}/{MachineName}/{CorrelationId}) {Message}{NewLine}{Exception}"
              }
            }
          ]
        }
      }
    ],
    "Enrich": [ "FromLogContext", "WithMachineName", "WithCorrelationIdHeader" ],
    "Properties": {
      "Application": "HappyCode.NetCoreBoilerplate.Api"
    }
  }
```

My small change fixes the issue.

---

Also fixed issue #31 by getting correlationId from Response Header if already exists.