### PR TITLE
Added middleware to supply Response with "x-correlation-id" header

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.cs]
+indent_size = 4
+
+dotnet_sort_system_directives_first = true
+csharp_prefer_braces = true:suggestion
+
+# private fields with underscore prefix => private int _myValue;
+dotnet_naming_rule.private_members_with_underscore.symbols  = private_fields
+dotnet_naming_rule.private_members_with_underscore.style    = prefix_underscore
+dotnet_naming_rule.private_members_with_underscore.severity = suggestion
+
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_style.prefix_underscore.capitalization  = camel_case
+dotnet_naming_style.prefix_underscore.required_prefix = _

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,12 @@ _TeamCity*
 # DotCover is a Code Coverage Tool
 *.dotCover
 
+# Coverlet is a Code Coverage Tool
+CoverageReports
+coverage*.json
+coverage*.xml
+*.opencover.xml
+
 # NCrunch
 _NCrunch_*
 .*crunch*.local.xml

--- a/README.md
+++ b/README.md
@@ -76,3 +76,22 @@ namespace MyWebApp
 ```
 
 You need to register the `IHttpContextAccessor` singleton so that the enricher has access to the requests `HttpContext` so that it can attach the correlation ID to the request/response.
+
+## ASP.NET Core - CorrelationIdHeaderSupplier Middleware
+
+Additionally you can use `CorrelationIdHeaderSupplierMiddleware` in your application by calling `UseCorrelationIdHeaderSupplier(headerKey)`. It is responsible for:
+
+* rewrite `x-correlation-id` header from `Request` to `Response`
+* create `x-correlation-id` header and supply `Response` when it is not provided in the request
+
+```cs
+using Serilog.Enrichers.CorrelationId.Middlewares;
+
+public void ConfigureServices(IServiceCollection services)
+{
+    // ...
+    app.UseCorrelationIdHeaderSupplier();
+    app.UseMvc();
+    // ...
+}
+```

--- a/src/CoverageReports/.gitignore
+++ b/src/CoverageReports/.gitignore
@@ -1,1 +1,0 @@
-*.opencover.xml

--- a/src/Serilog.Enrichers.CorrelationId.Tests/Middlewares/CorrelationIdHeaderSupplierMiddlewareTests.cs
+++ b/src/Serilog.Enrichers.CorrelationId.Tests/Middlewares/CorrelationIdHeaderSupplierMiddlewareTests.cs
@@ -1,0 +1,49 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+using Serilog.Enrichers;
+using Serilog.Enrichers.CorrelationId.Middlewares;
+
+namespace Serilog.Tests.Middlewares
+{
+    [TestFixture]
+    [Parallelizable]
+    public class CorrelationIdHeaderSupplierMiddlewareTests
+    {
+        private readonly RequestDelegate _onNext = (innerHttpContext) => { return Task.CompletedTask; };
+
+        [Test]
+        public void WhenNoCorrelationIdInRequest_ThenShould_CreateNewOne()
+        {
+            const string headerKey = "some-correlation-id-key";
+            var context = new DefaultHttpContext();
+
+            new CorrelationIdHeaderSupplierMiddleware(_onNext, headerKey).Invoke(context);
+
+            var correlationIdFromItems = (string)context.Items[CorrelationIdConstants.CorrelationIdItemName];
+            context.Response.Headers.TryGetValue(headerKey, out var correlationIdFromResponse);
+
+            Assert.IsNotEmpty(correlationIdFromItems);
+            Assert.IsNotEmpty(correlationIdFromResponse);
+            Assert.AreEqual(correlationIdFromItems, correlationIdFromResponse);
+        }
+
+        [Test]
+        public void WhenCorrelationIdSuppliedInRequest_ThenShould_ReuseIt()
+        {
+            const string correlationId = "some correlation id value";
+            var context = new DefaultHttpContext();
+            context.Request.Headers.Add(CorrelationIdConstants.CorrelationIdHeaderKay, correlationId);
+
+            new CorrelationIdHeaderSupplierMiddleware(_onNext).Invoke(context);
+
+            var correlationIdFromItems = (string)context.Items[CorrelationIdConstants.CorrelationIdItemName];
+            context.Response.Headers.TryGetValue(CorrelationIdConstants.CorrelationIdHeaderKay, out var correlationIdFromResponse);
+
+            Assert.IsNotEmpty(correlationIdFromItems);
+            Assert.IsNotEmpty(correlationIdFromResponse);
+            Assert.AreEqual(correlationId, correlationIdFromItems);
+            Assert.AreEqual(correlationId, correlationIdFromResponse);
+        }
+    }
+}

--- a/src/Serilog.Enrichers.CorrelationId/CorrelationIdLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Enrichers.CorrelationId/CorrelationIdLoggerConfigurationExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Serilog.Configuration;
 using Serilog.Enrichers;
 
@@ -14,7 +14,7 @@ namespace Serilog
 
         public static LoggerConfiguration WithCorrelationIdHeader(
             this LoggerEnrichmentConfiguration enrichmentConfiguration,
-            string headerKey = "x-correlation-id")
+            string headerKey = CorrelationIdConstants.CorrelationIdHeaderKay)
         {
             if (enrichmentConfiguration == null) throw new ArgumentNullException(nameof(enrichmentConfiguration));
             return enrichmentConfiguration.With(new CorrelationIdHeaderEnricher(headerKey));

--- a/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdConstants.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdConstants.cs
@@ -1,0 +1,8 @@
+namespace Serilog.Enrichers
+{
+    public class CorrelationIdConstants
+    {
+        public const string CorrelationIdItemName = "CorrelationIdEnricher+CorrelationId";
+        public const string CorrelationIdHeaderKay = "x-correlation-id";
+    }
+}

--- a/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdEnricher.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdEnricher.cs
@@ -13,7 +13,8 @@ namespace Serilog.Enrichers
     public class CorrelationIdEnricher : ILogEventEnricher
     {
         private const string CorrelationIdPropertyName = "CorrelationId";
-        private static readonly string CorrelationIdItemName = $"{typeof(CorrelationIdEnricher).Name}+CorrelationId";
+        private static readonly string CorrelationIdItemName = $"{nameof(CorrelationIdEnricher)}+CorrelationId";
+
         private readonly IHttpContextAccessor _contextAccessor;
 
         public CorrelationIdEnricher() : this(new HttpContextAccessor())
@@ -28,7 +29,9 @@ namespace Serilog.Enrichers
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
         {
             if (_contextAccessor.HttpContext == null)
+            {
                 return;
+            }
 
             var correlationId = GetCorrelationId();
 

--- a/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdEnricher.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdEnricher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 #if NETFULL
 using Serilog.Enrichers.CorrelationId.Accessors;
@@ -20,8 +20,8 @@ namespace Serilog.Enrichers
 
         protected override string GetCorrelationId()
         {
-            return (string)(ContextAccessor.HttpContext.Items[CorrelationIdItemName] ??
-                             (ContextAccessor.HttpContext.Items[CorrelationIdItemName] = Guid.NewGuid().ToString()));
+            return (string)(ContextAccessor.HttpContext.Items[CorrelationIdConstants.CorrelationIdItemName] ??
+                             (ContextAccessor.HttpContext.Items[CorrelationIdConstants.CorrelationIdItemName] = Guid.NewGuid().ToString()));
         }
     }
 }

--- a/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdEnricher.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdEnricher.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using Serilog.Core;
-using Serilog.Events;
 
 #if NETFULL
 using Serilog.Enrichers.CorrelationId.Accessors;
@@ -10,40 +8,20 @@ using Microsoft.AspNetCore.Http;
 
 namespace Serilog.Enrichers
 {
-    public class CorrelationIdEnricher : ILogEventEnricher
+    public class CorrelationIdEnricher : CorrelationIdEnricherBase
     {
-        private const string CorrelationIdPropertyName = "CorrelationId";
-        private static readonly string CorrelationIdItemName = $"{nameof(CorrelationIdEnricher)}+CorrelationId";
-
-        private readonly IHttpContextAccessor _contextAccessor;
-
         public CorrelationIdEnricher() : this(new HttpContextAccessor())
         {
         }
 
-        internal CorrelationIdEnricher(IHttpContextAccessor contextAccessor)
+        internal CorrelationIdEnricher(IHttpContextAccessor contextAccessor) : base(contextAccessor)
         {
-            _contextAccessor = contextAccessor;
         }
 
-        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        protected override string GetCorrelationId()
         {
-            if (_contextAccessor.HttpContext == null)
-            {
-                return;
-            }
-
-            var correlationId = GetCorrelationId();
-
-            var correlationIdProperty = new LogEventProperty(CorrelationIdPropertyName, new ScalarValue(correlationId));
-
-            logEvent.AddOrUpdateProperty(correlationIdProperty);
-        }
-
-        private string GetCorrelationId()
-        {
-            return (string) (_contextAccessor.HttpContext.Items[CorrelationIdItemName] ??
-                             (_contextAccessor.HttpContext.Items[CorrelationIdItemName] = Guid.NewGuid().ToString()));
+            return (string)(ContextAccessor.HttpContext.Items[CorrelationIdItemName] ??
+                             (ContextAccessor.HttpContext.Items[CorrelationIdItemName] = Guid.NewGuid().ToString()));
         }
     }
 }

--- a/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdEnricherBase.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdEnricherBase.cs
@@ -1,0 +1,40 @@
+﻿using Serilog.Core;
+using Serilog.Events;
+
+#if NETFULL
+using Serilog.Enrichers.CorrelationId.Accessors;
+#else
+using Microsoft.AspNetCore.Http;
+#endif
+
+namespace Serilog.Enrichers
+{
+    public abstract class CorrelationIdEnricherBase: ILogEventEnricher
+    {
+        protected const string CorrelationIdPropertyName = "CorrelationId";
+        protected static readonly string CorrelationIdItemName = $"{nameof(CorrelationIdEnricherBase)}+CorrelationId";
+
+        protected readonly IHttpContextAccessor ContextAccessor;
+
+        public CorrelationIdEnricherBase(IHttpContextAccessor contextAccessor)
+        {
+            ContextAccessor = contextAccessor;
+        }
+
+        protected abstract string GetCorrelationId();
+
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            if (ContextAccessor.HttpContext == null)
+            {
+                return;
+            }
+
+            var correlationId = GetCorrelationId();
+
+            var correlationIdProperty = new LogEventProperty(CorrelationIdPropertyName, new ScalarValue(correlationId));
+
+            logEvent.AddOrUpdateProperty(correlationIdProperty);
+        }
+    }
+}

--- a/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdEnricherBase.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdEnricherBase.cs
@@ -1,4 +1,4 @@
-﻿using Serilog.Core;
+using Serilog.Core;
 using Serilog.Events;
 
 #if NETFULL
@@ -11,8 +11,7 @@ namespace Serilog.Enrichers
 {
     public abstract class CorrelationIdEnricherBase: ILogEventEnricher
     {
-        protected const string CorrelationIdPropertyName = "CorrelationId";
-        protected static readonly string CorrelationIdItemName = $"{nameof(CorrelationIdEnricherBase)}+CorrelationId";
+        private const string _correlationIdPropertyName = "CorrelationId";
 
         protected readonly IHttpContextAccessor ContextAccessor;
 
@@ -32,7 +31,7 @@ namespace Serilog.Enrichers
 
             var correlationId = GetCorrelationId();
 
-            var correlationIdProperty = new LogEventProperty(CorrelationIdPropertyName, new ScalarValue(correlationId));
+            var correlationIdProperty = new LogEventProperty(_correlationIdPropertyName, new ScalarValue(correlationId));
 
             logEvent.AddOrUpdateProperty(correlationIdProperty);
         }

--- a/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdHeaderEnricher.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdHeaderEnricher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 
 #if NETFULL
@@ -36,16 +36,16 @@ namespace Serilog.Enrichers
                 correlationId = values.FirstOrDefault();
             }
 #if NETFULL
-            else if (ContextAccessor.HttpContext.Items.Contains(CorrelationIdItemName))
+            else if (ContextAccessor.HttpContext.Items.Contains(CorrelationIdConstants.CorrelationIdItemName))
 #else
-            else if (ContextAccessor.HttpContext.Items.ContainsKey(CorrelationIdItemName))
+            else if (ContextAccessor.HttpContext.Items.ContainsKey(CorrelationIdConstants.CorrelationIdItemName))
 #endif
             {
-                correlationId = (string)ContextAccessor.HttpContext.Items[CorrelationIdItemName];
+                correlationId = (string)ContextAccessor.HttpContext.Items[CorrelationIdConstants.CorrelationIdItemName];
             }
             else
             {
-                ContextAccessor.HttpContext.Items[CorrelationIdItemName] = correlationId;
+                ContextAccessor.HttpContext.Items[CorrelationIdConstants.CorrelationIdItemName] = correlationId;
             }
 
             return correlationId;

--- a/src/Serilog.Enrichers.CorrelationId/Middlewares/CorrelationIdHeaderSupplierMiddleware.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Middlewares/CorrelationIdHeaderSupplierMiddleware.cs
@@ -12,7 +12,7 @@ namespace Serilog.Enrichers.CorrelationId.Middlewares
         private readonly RequestDelegate _next;
         private readonly string _headerKey;
 
-        public CorrelationIdHeaderSupplierMiddleware(RequestDelegate next, string headerKey = "x-correlation-id")
+        public CorrelationIdHeaderSupplierMiddleware(RequestDelegate next, string headerKey = CorrelationIdConstants.CorrelationIdHeaderKay)
         {
             _next = next;
             _headerKey = headerKey;
@@ -23,17 +23,23 @@ namespace Serilog.Enrichers.CorrelationId.Middlewares
             string correlationId = httpContext.Request.Headers.TryGetValue(_headerKey, out var values)
                 ? values.First()
                 : Guid.NewGuid().ToString();
+
+            if (!httpContext.Items.ContainsKey(CorrelationIdConstants.CorrelationIdItemName))
+            {
+                httpContext.Items.Add(CorrelationIdConstants.CorrelationIdItemName, correlationId);
+            }
             if (!httpContext.Response.Headers.ContainsKey(_headerKey))
             {
                 httpContext.Response.Headers.Add(_headerKey, correlationId);
             }
+
             return _next(httpContext);
         }
     }
 
     public static class CorrelationIdHeaderSupplierMiddlewareExtensions
     {
-        public static IApplicationBuilder UseCorrelationIdHeaderSupplier(this IApplicationBuilder builder, string headerKey = "x-correlation-id")
+        public static IApplicationBuilder UseCorrelationIdHeaderSupplier(this IApplicationBuilder builder, string headerKey = CorrelationIdConstants.CorrelationIdHeaderKay)
         {
             return builder.UseMiddleware<CorrelationIdHeaderSupplierMiddleware>(headerKey);
         }

--- a/src/Serilog.Enrichers.CorrelationId/Middlewares/CorrelationIdHeaderSupplierMiddleware.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Middlewares/CorrelationIdHeaderSupplierMiddleware.cs
@@ -1,0 +1,44 @@
+#if NETCORE
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace Serilog.Enrichers.CorrelationId.Middlewares
+{
+    public class CorrelationIdHeaderSupplierMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly string _headerKey;
+
+        public CorrelationIdHeaderSupplierMiddleware(RequestDelegate next, string headerKey = "x-correlation-id")
+        {
+            _next = next;
+            _headerKey = headerKey;
+        }
+
+        public Task Invoke(HttpContext httpContext)
+        {
+            string correlationId = Guid.NewGuid().ToString();
+            if (httpContext.Request.Headers.TryGetValue(_headerKey, out var values))
+            {
+                correlationId = values.First();
+            }
+            if (!httpContext.Response.Headers.ContainsKey(_headerKey))
+            {
+                httpContext.Response.Headers.Add(_headerKey, correlationId);
+            }
+            return _next(httpContext);
+        }
+    }
+
+    public static class CorrelationIdHeaderSupplierMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseCorrelationIdHeaderSupplier(this IApplicationBuilder builder, string headerKey = "x-correlation-id")
+        {
+            return builder.UseMiddleware<CorrelationIdHeaderSupplierMiddleware>(headerKey);
+        }
+    }
+}
+#endif

--- a/src/Serilog.Enrichers.CorrelationId/Middlewares/CorrelationIdHeaderSupplierMiddleware.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Middlewares/CorrelationIdHeaderSupplierMiddleware.cs
@@ -20,11 +20,9 @@ namespace Serilog.Enrichers.CorrelationId.Middlewares
 
         public Task Invoke(HttpContext httpContext)
         {
-            string correlationId = Guid.NewGuid().ToString();
-            if (httpContext.Request.Headers.TryGetValue(_headerKey, out var values))
-            {
-                correlationId = values.First();
-            }
+            string correlationId = httpContext.Request.Headers.TryGetValue(_headerKey, out var values)
+                ? values.First()
+                : Guid.NewGuid().ToString();
             if (!httpContext.Response.Headers.ContainsKey(_headerKey))
             {
                 httpContext.Response.Headers.Add(_headerKey, correlationId);


### PR DESCRIPTION
* added asp.net core middleware to supply `Response` with "x-correlation-id" header
* total fix for same `correlationId` in `CorrelationIdHeaderEnricher`
* added `CorrelationIdEnricherBase` base class
* added .editorconfig file

still to do:
* kind of middleware, kind of interceptor to rewrite `x-correlation-id` header in full framework