### PR TITLE
Moving Microsoft.AspNetCore.Http to 2.1.1 for netstandard2.0

### DIFF
--- a/src/Serilog.Enrichers.CorrelationId/Serilog.Enrichers.CorrelationId.csproj
+++ b/src/Serilog.Enrichers.CorrelationId/Serilog.Enrichers.CorrelationId.csproj
@@ -19,7 +19,7 @@
     </PropertyGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
         <PackageReference Include="Serilog" Version="2.9.0" />
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">


### PR DESCRIPTION
I tried to use your library with a .net core 2.1 app and the Nuget package description doesn't match the actual implementation : 

In Nuget : 
> .NETStandard 2.0
> Microsoft.AspNetCore.Http (>= 2.1.1)
> Serilog (>= 2.7.1)

My change is moving Microsoft.AspNetCore.Http to the version 2.1.1