### PR TITLE
Add check for headers already having been written

### DIFF
--- a/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdHeaderEnricher.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdHeaderEnricher.cs
@@ -58,10 +58,10 @@ namespace Serilog.Enrichers
                                     : header;
 
 #if NETFULL
-            if(!_contextAccessor.HttpContext.Response.HeadersWritten &&
+            if (!_contextAccessor.HttpContext.Response.HeadersWritten &&
                 !_contextAccessor.HttpContext.Response.Headers.AllKeys.Contains(_headerKey))
 #else
-            if(!_contextAccessor.HttpContext.Response.Headers.IsReadOnly &&
+            if (!_contextAccessor.HttpContext.Response.Headers.IsReadOnly &&
                 !_contextAccessor.HttpContext.Response.Headers.ContainsKey(_headerKey))
 #endif
             {

--- a/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdHeaderEnricher.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdHeaderEnricher.cs
@@ -61,7 +61,8 @@ namespace Serilog.Enrichers
             if(!_contextAccessor.HttpContext.Response.HeadersWritten &&
                 !_contextAccessor.HttpContext.Response.Headers.AllKeys.Contains(_headerKey))
 #else
-            if (!_contextAccessor.HttpContext.Response.Headers.ContainsKey(_headerKey))
+            if(!_contextAccessor.HttpContext.Response.Headers.IsReadOnly &&
+                !_contextAccessor.HttpContext.Response.Headers.ContainsKey(_headerKey))
 #endif
             {
                 _contextAccessor.HttpContext.Response.Headers.Add(_headerKey, correlationId);


### PR DESCRIPTION
Was getting exceptions under .Net Core, and traced it down to there not being a matching check for the headers having already been sent to match the one for the NETFULL region.