### PR TITLE
Updates dependencies for netcore 3.1 & net5.0

### DIFF
--- a/src/Serilog.Enrichers.CorrelationId.Tests/Serilog.Enrichers.CorrelationId.Tests.csproj
+++ b/src/Serilog.Enrichers.CorrelationId.Tests/Serilog.Enrichers.CorrelationId.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <RootNamespace>Serilog.Tests</RootNamespace>
-    </PropertyGroup>    
+    </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="FakeItEasy" Version="5.4.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
@@ -11,7 +11,6 @@
         <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
         <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
         <PackageReference Include="coverlet.msbuild" Version="2.7.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\Serilog.Enrichers.CorrelationId\Serilog.Enrichers.CorrelationId.csproj" />

--- a/src/Serilog.Enrichers.CorrelationId/Serilog.Enrichers.CorrelationId.csproj
+++ b/src/Serilog.Enrichers.CorrelationId/Serilog.Enrichers.CorrelationId.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <AssemblyName>Serilog.Enrichers.CorrelationId</AssemblyName>
         <RootNamespace>Serilog</RootNamespace>
-        <TargetFrameworks>net452;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
         <LangVersion>7.3</LangVersion>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
@@ -24,6 +24,14 @@
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
         <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+        <PackageReference Include="Serilog" Version="2.9.0" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="Serilog" Version="2.9.0" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Serilog" Version="2.9.0" />
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net452'">


### PR DESCRIPTION
As pr https://github.com/dotnet/aspnetcore/issues/3756 , `Microsoft.AspNetCore.Http` has been moved into the shared framework (installed via the runtimes) as of ASP.NET Core 3.0.

This PR makes projects targeting netcoreapp3.1 or net5.0 avoid taking a transient dependency on the older  Microsoft.AspNetCore.Http/2.2.2, but use the one newest from the shared framework version instead.
