### PR TITLE
Support for custom correlation ID generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ The package includes:
  * `WithCorrelationId()` - adds a `CorrelationId` to track logs for the current web request.
  * `WithCorrelationIdHeader(headerKey)` - adds a `CorrelationId` extracted from the current request header (or created if one does not exist).
 
+### Use custom correlation ID generator
+
+By default the correlation ID is a GUID Value (example: `37546029-2816-4aee-b8c9-a38c1d25ad18`).
+
+But it's possible to generate custom values by implementing `ICorrelationIdGenerator` and configure the enricher.
+
+* `WithCorrelationId(new CorrelationIdGenerator())`
+* `WithCorrelationIdHeader(headerKey, new CorrelationIdGenerator())`
+
 ## Installing into an ASP.NET Core Web Application
 
 This is what your `Startup` class should contain in order for this enricher to work as expected:

--- a/src/Serilog.Enrichers.CorrelationId.Tests/Enrichers/CorrelationIdEnricherTests.cs
+++ b/src/Serilog.Enrichers.CorrelationId.Tests/Enrichers/CorrelationIdEnricherTests.cs
@@ -15,7 +15,7 @@ namespace Serilog.Tests.Enrichers
         public void SetUp()
         {
             _httpContextAccessor = A.Fake<IHttpContextAccessor>();
-            _enricher = new CorrelationIdEnricher(_httpContextAccessor);
+            _enricher = new CorrelationIdEnricher(_httpContextAccessor, new DefaultCorrelationIdGenerator());
         }
 
         private IHttpContextAccessor _httpContextAccessor;
@@ -39,7 +39,7 @@ namespace Serilog.Tests.Enrichers
             Assert.IsTrue(evt.Properties.ContainsKey("CorrelationId"));
             Assert.NotNull(evt.Properties["CorrelationId"].LiteralValue());
         }
-
+        
         [Test]
         public void When_CurrentHttpContextIsNotNull_ShouldNot_CreateCorrelationIdProperty()
         {
@@ -79,6 +79,28 @@ namespace Serilog.Tests.Enrichers
             log.Information(@"Here is another event");
 
             Assert.AreEqual(correlationId, evt.Properties["CorrelationId"].LiteralValue());
+        }
+        
+        [Test]
+        public void When_UsingCustomCorrelationIdGenerator_Should_CreateExpectedCorrelationId()
+        {
+            var enricher = new CorrelationIdEnricher(_httpContextAccessor, new CustomCorrelationIdGenerator());
+            
+            A.CallTo(() => _httpContextAccessor.HttpContext)
+                .Returns(new DefaultHttpContext());
+
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .Enrich.With(enricher)
+                .WriteTo.Sink(new DelegateSink.DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information(@"Has a Custom CorrelationId property");
+
+            Assert.NotNull(evt);
+            Assert.IsTrue(evt.Properties.ContainsKey("CorrelationId"));
+            Assert.NotNull(evt.Properties["CorrelationId"].LiteralValue());
+            Assert.AreEqual(evt.Properties["CorrelationId"].LiteralValue(), CustomCorrelationIdGenerator.CustomCorrelationIdValue);
         }
     }
 }

--- a/src/Serilog.Enrichers.CorrelationId.Tests/Enrichers/DefaultCorrelationIdGeneratorTests.cs
+++ b/src/Serilog.Enrichers.CorrelationId.Tests/Enrichers/DefaultCorrelationIdGeneratorTests.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using NUnit.Framework;
+using Serilog.Enrichers;
+
+namespace Serilog.Tests.Enrichers
+{
+    [TestFixture]
+    [Parallelizable]
+    public class DefaultCorrelationIdGeneratorTests
+    {
+        [Test]
+        public void When_CallingDefaultCorrelationIdGenerator_Should_ReturnValidGuid()
+        {
+            var generator = new DefaultCorrelationIdGenerator( );
+
+            var sut = generator.Generate( );
+
+            Assert.NotNull(sut);
+            Assert.IsNotEmpty(sut);
+            Assert.IsTrue(Guid.TryParse(sut, out var _));
+        }
+    }
+}

--- a/src/Serilog.Enrichers.CorrelationId.Tests/Support/CustomCorrelationIdGenerator.cs
+++ b/src/Serilog.Enrichers.CorrelationId.Tests/Support/CustomCorrelationIdGenerator.cs
@@ -1,0 +1,14 @@
+﻿using Serilog.Enrichers;
+
+namespace Serilog.Tests.Support
+{
+    public class CustomCorrelationIdGenerator : ICorrelationIdGenerator
+    {
+        public static string CustomCorrelationIdValue = "CustomCorrelationIdValue";
+        
+        public string Generate()
+        {
+            return CustomCorrelationIdValue;
+        }
+    }
+}

--- a/src/Serilog.Enrichers.CorrelationId/CorrelationIdLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Enrichers.CorrelationId/CorrelationIdLoggerConfigurationExtensions.cs
@@ -6,18 +6,23 @@ namespace Serilog
 {
     public static class CorrelationIdLoggerConfigurationExtensions
     {
-        public static LoggerConfiguration WithCorrelationId(this LoggerEnrichmentConfiguration enrichmentConfiguration)
+        public static LoggerConfiguration WithCorrelationId(
+            this LoggerEnrichmentConfiguration enrichmentConfiguration,
+            ICorrelationIdGenerator correlationIdGenerator = null)
         {
             if (enrichmentConfiguration == null) throw new ArgumentNullException(nameof(enrichmentConfiguration));
-            return enrichmentConfiguration.With<CorrelationIdEnricher>();
+            correlationIdGenerator = correlationIdGenerator ?? new DefaultCorrelationIdGenerator( );
+            return enrichmentConfiguration.With(new CorrelationIdEnricher(correlationIdGenerator));
         }
 
         public static LoggerConfiguration WithCorrelationIdHeader(
             this LoggerEnrichmentConfiguration enrichmentConfiguration,
-            string headerKey = "x-correlation-id")
+            string headerKey = "x-correlation-id",
+            ICorrelationIdGenerator correlationIdGenerator = null)
         {
             if (enrichmentConfiguration == null) throw new ArgumentNullException(nameof(enrichmentConfiguration));
-            return enrichmentConfiguration.With(new CorrelationIdHeaderEnricher(headerKey));
+            correlationIdGenerator = correlationIdGenerator ?? new DefaultCorrelationIdGenerator( );
+            return enrichmentConfiguration.With(new CorrelationIdHeaderEnricher(headerKey, correlationIdGenerator));
         }
     }
 }

--- a/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdEnricher.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdEnricher.cs
@@ -15,14 +15,16 @@ namespace Serilog.Enrichers
         private const string CorrelationIdPropertyName = "CorrelationId";
         private static readonly string CorrelationIdItemName = $"{typeof(CorrelationIdEnricher).Name}+CorrelationId";
         private readonly IHttpContextAccessor _contextAccessor;
+        private readonly ICorrelationIdGenerator _correlationIdGenerator;
 
-        public CorrelationIdEnricher() : this(new HttpContextAccessor())
+        public CorrelationIdEnricher(ICorrelationIdGenerator correlationIdGenerator) : this(new HttpContextAccessor(), correlationIdGenerator)
         {
         }
 
-        internal CorrelationIdEnricher(IHttpContextAccessor contextAccessor)
+        internal CorrelationIdEnricher(IHttpContextAccessor contextAccessor, ICorrelationIdGenerator correlationIdGenerator)
         {
             _contextAccessor = contextAccessor;
+            _correlationIdGenerator = correlationIdGenerator;
         }
 
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
@@ -40,7 +42,7 @@ namespace Serilog.Enrichers
         private string GetCorrelationId()
         {
             return (string) (_contextAccessor.HttpContext.Items[CorrelationIdItemName] ??
-                             (_contextAccessor.HttpContext.Items[CorrelationIdItemName] = Guid.NewGuid().ToString()));
+                             (_contextAccessor.HttpContext.Items[CorrelationIdItemName] = this._correlationIdGenerator.Generate()));
         }
     }
 }

--- a/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdHeaderEnricher.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdHeaderEnricher.cs
@@ -17,15 +17,21 @@ namespace Serilog.Enrichers
         private const string CorrelationIdPropertyName = "CorrelationId";
         private readonly string _headerKey;
         private readonly IHttpContextAccessor _contextAccessor;
+        private readonly ICorrelationIdGenerator _correlationIdGenerator;
 
-        public CorrelationIdHeaderEnricher(string headerKey) : this(headerKey, new HttpContextAccessor())
+        public CorrelationIdHeaderEnricher(string headerKey, ICorrelationIdGenerator correlationIdGenerator)
+            : this(headerKey, correlationIdGenerator, new HttpContextAccessor())
         {
         }
 
-        internal CorrelationIdHeaderEnricher(string headerKey, IHttpContextAccessor contextAccessor)
+        internal CorrelationIdHeaderEnricher(
+            string headerKey,
+            ICorrelationIdGenerator correlationIdGenerator,
+            IHttpContextAccessor contextAccessor)
         {
             _headerKey = headerKey;
             _contextAccessor = contextAccessor;
+            _correlationIdGenerator = correlationIdGenerator;
         }
 
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
@@ -54,7 +60,7 @@ namespace Serilog.Enrichers
             }
 
             var correlationId = string.IsNullOrEmpty(header)
-                                    ? Guid.NewGuid().ToString()
+                                    ? this._correlationIdGenerator.Generate()
                                     : header;
 
 #if NETFULL

--- a/src/Serilog.Enrichers.CorrelationId/Enrichers/DefaultCorrelationIdGenerator.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Enrichers/DefaultCorrelationIdGenerator.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Serilog.Enrichers
+{
+    public class DefaultCorrelationIdGenerator : ICorrelationIdGenerator
+    {
+        public string Generate()
+        {
+            return Guid.NewGuid( ).ToString( );
+        }
+    }
+}

--- a/src/Serilog.Enrichers.CorrelationId/Enrichers/ICorrelationIdGenerator.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Enrichers/ICorrelationIdGenerator.cs
@@ -1,0 +1,7 @@
+﻿namespace Serilog.Enrichers
+{
+    public interface ICorrelationIdGenerator
+    {
+        string Generate();
+    }
+}


### PR DESCRIPTION
With this change it's possible to introduce custom correlation ID generators. By default GUID values are generated. But by implementing `ICorrelationIdGenerator` interface and providing a generator instance custom values are possible.

In my case, I had to add a prefix for the service, so for other services it's clear, where the correlation ID comes from.