### PR TITLE
Fix for ASP.NET Core exception Headers are read-only, response has al…

### DIFF
--- a/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdHeaderEnricher.cs
+++ b/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdHeaderEnricher.cs
@@ -61,7 +61,9 @@ namespace Serilog.Enrichers
             if(!_contextAccessor.HttpContext.Response.HeadersWritten &&
                 !_contextAccessor.HttpContext.Response.Headers.AllKeys.Contains(_headerKey))
 #else
-            if (!_contextAccessor.HttpContext.Response.Headers.ContainsKey(_headerKey))
+            if (!_contextAccessor.HttpContext.Response.Headers.IsReadOnly &&
+                !_contextAccessor.HttpContext.Response.HasStarted &&
+                !_contextAccessor.HttpContext.Response.Headers.ContainsKey(_headerKey))
 #endif
             {
                 _contextAccessor.HttpContext.Response.Headers.Add(_headerKey, correlationId);


### PR DESCRIPTION
"…ready started"

This patch fixes the following issues:

Exception System.InvalidOperationException: Headers are read-only, response has already started.
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpHeaders.ThrowHeadersReadOnlyException()
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpHeaders.System.Collections.Generic.IDictionary<System.String,Microsoft.Extensions.Primitives.StringValues>.Add(String key, StringValues value)
   at Serilog.Enrichers.CorrelationIdHeaderEnricher.GetCorrelationId()
   at Serilog.Enrichers.CorrelationIdHeaderEnricher.Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
   at Serilog.Core.Enrichers.SafeAggregateEnricher.Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory) caught while enriching Serilog.Events.LogEvent with Serilog.Enrichers.CorrelationIdHeaderEnricher.